### PR TITLE
Group 0 - all lights

### DIFF
--- a/server/hue-server.coffee
+++ b/server/hue-server.coffee
@@ -25,17 +25,17 @@ Meteor.methods
         Lights.upsert({id: k}, v)
 
   allOn: ->
-    url = "http://#{bridge.local_ip}/api/#{bridge.hue_user}/groups/1/action"
+    url = "http://#{bridge.local_ip}/api/#{bridge.hue_user}/groups/0/action"
     Meteor.http.call "PUT", url, { content: onState }
     Meteor.call "setLightsData"
 
   allOff: ->
-    url = "http://#{bridge.local_ip}/api/#{bridge.hue_user}/groups/1/action"
+    url = "http://#{bridge.local_ip}/api/#{bridge.hue_user}/groups/0/action"
     Meteor.http.call "PUT", url, { content: offState }
     Meteor.call "setLightsData"
 
   allDefault: ->
-    url = "http://#{bridge.local_ip}/api/#{bridge.hue_user}/groups/1/action"
+    url = "http://#{bridge.local_ip}/api/#{bridge.hue_user}/groups/0/action"
     Meteor.http.call "PUT", url, { content: defaultState }
     Meteor.call "setLightsData"
 


### PR DESCRIPTION
Hello,

Some bulbs didn't respond to the "all" commands. The bulbs I added after a year or so of using my hue.

I looked into the Hue API.
Group 0 - API V 1.0
A special group containing all lights in the system, and is not returned by the ‘get all groups’ command.
http://www.developers.meethue.com/documentation/groups-api

It might help for somebody else who is trying your code.
If it's ok with you, I'm extending it to include group management in another repo.

Thank you, for sharing!

Signed-off-by: Jorge Morales <jorge@magneticore.com>